### PR TITLE
Add a dependency from the resolver to the dataSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 cdk.out
+index.js
+packaged.yaml

--- a/index.ts
+++ b/index.ts
@@ -118,6 +118,7 @@ export class AppSyncCdkStack extends cdk.Stack {
       #end`
     });
     putEventResolver.addDependsOn(apiSchema);
+    putEventResolver.addDependsOn(dataSource);
 
     const echoLambda = new lambda.Function(this, "echoFunction", {
       code: lambda.Code.fromInline(


### PR DESCRIPTION
This worked great for me.  Thank you, Ed.

I discovered that I needed a dependency between the resolver and the data source, so submitting a PR for it.